### PR TITLE
Restore minLength and maxLength support to HAL FORMS parsing

### DIFF
--- a/src/state/hal.ts
+++ b/src/state/hal.ts
@@ -335,6 +335,8 @@ function parseHalField(halField: hal.HalFormsProperty): Field {
           pattern: halField.regex ? new RegExp(halField.regex) : undefined,
           label: halField.prompt,
           placeholder: halField.placeHolder,
+          minLength: halField.minLength,
+          maxLength: halField.maxLength,
         };
       }
     case 'hidden' :
@@ -346,6 +348,8 @@ function parseHalField(halField: hal.HalFormsProperty): Field {
         value: halField.value,
         label: halField.prompt,
         placeholder: halField.placeHolder,
+        minLength: halField.minLength,
+        maxLength: halField.maxLength,
       };
     case 'textarea' :
       return {
@@ -358,6 +362,8 @@ function parseHalField(halField: hal.HalFormsProperty): Field {
         placeholder: halField.placeHolder,
         cols: halField.cols,
         rows: halField.rows,
+        minLength: halField.minLength,
+        maxLength: halField.maxLength,
       };
     case 'password' :
       return {
@@ -367,6 +373,8 @@ function parseHalField(halField: hal.HalFormsProperty): Field {
         readOnly: halField.readOnly || false,
         label: halField.prompt,
         placeholder: halField.placeHolder,
+        minLength: halField.minLength,
+        maxLength: halField.maxLength,
       };
     case 'date' :
     case 'month' :


### PR DESCRIPTION
Restored parsing of minLength and maxLength for use in input and textarea fields.